### PR TITLE
Minor changes to headers in client.go

### DIFF
--- a/client.go
+++ b/client.go
@@ -39,7 +39,7 @@ func NewClient(rawURL, schema string, headers map[string]string) *Client {
 	c.clientTransport.header.Set("Content-Type", "application/json")
 	c.clientTransport.header.Set("Accept-Profile", schema)
 	c.clientTransport.header.Set("Content-Profile", schema)
-	c.clientTransport.header.Set("X-Client-Info: ", "postgrest-go/"+version)
+	c.clientTransport.header.Set("X-Client-Info", "postgrest-go/"+version)
 
 	// Set optional headers if exist
 	for key, value := range headers {

--- a/client.go
+++ b/client.go
@@ -57,6 +57,7 @@ type Client struct {
 
 func (c *Client) TokenAuth(token string) *Client {
 	c.clientTransport.header.Set("Authorization", "Basic "+token)
+	c.clientTransport.header.Set("apiKey", token)
 	return c
 }
 

--- a/client.go
+++ b/client.go
@@ -57,7 +57,7 @@ type Client struct {
 
 func (c *Client) TokenAuth(token string) *Client {
 	c.clientTransport.header.Set("Authorization", "Basic "+token)
-	c.clientTransport.header.Set("apiKey", token)
+	c.clientTransport.header.Set("apikey", token)
 	return c
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/supabase-community/postgrest-go/issues/20, I think that the two changes in this PR will solve bugs. I have no idea if others also experienced this, but for me both the missing header and the "wrong" header name made the package unusable for me.

I am using go 1.17 btw.