### PR TITLE
Update the base URL to use REST v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import (
 )
 
 func main() {
-	client := postgrest.NewClient("http://localhost:3000", "", nil)
+	client := postgrest.NewClient("http://localhost:3000/rest/v1", "", nil)
 	if client.ClientError != nil {
 		panic(client.ClientError)
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update the README with the updated base URL to use REST v1.

## What is the current behavior?

[Issue link](https://github.com/supabase-community/postgrest-go/issues/28).

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
