### PR TITLE
Feature client transport config

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,7 +31,7 @@ func NewClient(rawURL, schema string, headers map[string]string) *Client {
 	t := transport{
 		header:  http.Header{},
 		baseURL: *baseURL,
-		Parent:  http.DefaultTransport,
+		Parent:  nil,
 	}
 
 	c := Client{
@@ -164,5 +164,11 @@ func (t transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	req.URL = t.baseURL.ResolveReference(req.URL)
-	return t.Parent.RoundTrip(req)
+
+	// This is only needed with usage of httpmock in testing. It would be better to initialize
+	// t.Parent with http.DefaultTransport and then use t.Parent.RoundTrip(req)
+	if t.Parent != nil {
+		return t.Parent.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
 }

--- a/execute.go
+++ b/execute.go
@@ -31,7 +31,7 @@ func executeHelper(client *Client, method string, body []byte, urlFragments []st
 	}
 
 	readerBody := bytes.NewBuffer(body)
-	baseUrl := path.Join(append([]string{client.clientTransport.baseURL.Path}, urlFragments...)...)
+	baseUrl := path.Join(append([]string{client.Transport.baseURL.Path}, urlFragments...)...)
 	req, err := http.NewRequest(method, baseUrl, readerBody)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error creating request: %s", err.Error())


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add the possibility to define custom transport settings for the `http.Client`. Furthermore the renaming prevents stuttering (former `Client.clientTransport`)

## What is the current behavior?

Any information can be found in #39 

## What is the new behavior?

It is now possible to define custom transport behavior by setting `Client.Transport.Parent`: 
```
func main() {
	c := postgrest.NewClient("localhost:3000", "", nil)

	c.Transport.Parent = &http.Transport{
		TLSClientConfig: &tls.Config{
			RootCAs:            x509.NewCertPool(),
			InsecureSkipVerify: false,
		},
	}
}
```

## Additional information
Due to the behavior of `httpmock` used for testing, the implemented `RoundTrip()` is not as clean as it could be. For testing with `httpmock` to work properly `http.DefaultTransport.RoundTrip()` must be called in `RoundTrip()` in `client.go`. 