### PR TITLE
added functions for setting ApiKey and Authorization Headers

### DIFF
--- a/client.go
+++ b/client.go
@@ -81,10 +81,16 @@ func (c *Client) Ping() bool {
 	return true
 }
 
-// TokenAuth sets authorization headers for subsequent requests.
-func (c *Client) TokenAuth(token string) *Client {
-	c.clientTransport.header.Set("Authorization", "Bearer "+token)
-	c.clientTransport.header.Set("apikey", token)
+// SetApiKey sets api key header for subsequent requests.
+func (c *Client) SetApiKey(apiKey string) *Client {
+	c.clientTransport.header.Set("apikey", apiKey)
+	return c
+}
+
+
+// SetAuthToken sets authorization header for subsequent requests.
+func (c *Client) SetAuthToken(authToken string) *Client {
+	c.clientTransport.header.Set("Authorization", "Bearer "+authToken)
 	return c
 }
 

--- a/client.go
+++ b/client.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	version = "v0.0.7"
+	version = "v0.1.0"
 )
 
 type Client struct {

--- a/client.go
+++ b/client.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	version = "v0.0.6"
+	version = "v0.0.7"
 )
 
 type Client struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?
I removed the function `TokenAuth`, with `SetApiKey` and `SetAuthToken`, so that users can change the apiKey and authorization headers individually.


## What is the current behavior?
Currently TokenAuth sets the apiKey **and** authorization header

## What is the new behavior?
`postgres.SetAuthToken( authToken string) `will set the authorization header for subsequent request and
`postgres.SetApiKey( apiKey string)` will set the apiKey header for subsequent request

