### PR TITLE
feat: add "and" logical operator

### DIFF
--- a/filterbuilder.go
+++ b/filterbuilder.go
@@ -58,6 +58,15 @@ func (f *FilterBuilder) Filter(column, operator, value string) *FilterBuilder {
 	return f
 }
 
+func (f *FilterBuilder) And(filters, foreignTable string) *FilterBuilder {
+	if foreignTable != "" {
+		f.params[foreignTable+".and"] = fmt.Sprintf("(%s)", filters)
+	} else {
+		f.params[foreignTable+"and"] = fmt.Sprintf("(%s)", filters)
+	}
+	return f
+}
+
 func (f *FilterBuilder) Or(filters, foreignTable string) *FilterBuilder {
 	if foreignTable != "" {
 		f.params[foreignTable+".or"] = fmt.Sprintf("(%s)", filters)


### PR DESCRIPTION
## What kind of change does this PR introduce?
```
- doc: https://postgrest.org/en/stable/references/api/tables_views.html#logical-operators
- hint: couldn't find the documentation if "$foreignTable.and" is supported like "$foreignTable.or"
```