### PR TITLE
Fix malformed array literal cause by Overalps func

### DIFF
--- a/filterbuilder.go
+++ b/filterbuilder.go
@@ -196,7 +196,13 @@ func (f *FilterBuilder) RangeAdjacent(column, value string) *FilterBuilder {
 }
 
 func (f *FilterBuilder) Overlaps(column string, value []string) *FilterBuilder {
-	f.params[column] = "ov." + strings.Join(value, ",")
+	_new := []string{}
+	for _, v := range value {
+		_new = append(_new, fmt.Sprintf("%#v", v))
+	}
+
+	valueString := fmt.Sprintf("{%s}", strings.Join(_new, ","))
+	f.params[column] = "ov." + valueString
 	return f
 }
 

--- a/filterbuilder.go
+++ b/filterbuilder.go
@@ -196,12 +196,12 @@ func (f *FilterBuilder) RangeAdjacent(column, value string) *FilterBuilder {
 }
 
 func (f *FilterBuilder) Overlaps(column string, value []string) *FilterBuilder {
-	_new := []string{}
+	newValue := []string{}
 	for _, v := range value {
-		_new = append(_new, fmt.Sprintf("%#v", v))
+		newValue = append(newValue, fmt.Sprintf("%#v", v))
 	}
 
-	valueString := fmt.Sprintf("{%s}", strings.Join(_new, ","))
+	valueString := fmt.Sprintf("{%s}", strings.Join(newValue, ","))
 	f.params[column] = "ov." + valueString
 	return f
 }


### PR DESCRIPTION


https://www.postgresql.org/docs/current/arrays.html

## What kind of change does this PR introduce?
Correctly formatting the array used by the Overlap function

Bug fix, feature, docs update, ...
Arrays in Postgres use this string format  '{10000, 10000, 10000, 10000}' or '{"meeting", "lunch"}'

## What is the current behavior?
value `[]string{"foo", "bar"}` turns into `foo bar`

Please link any relevant issues here.
[Seeding database error while running locally
](https://discord.com/channels/839993398554656828/1167636913453281350)

## What is the new behavior?
Will turn **values** `[]string{"foo", "bar"}`  into `'{"foo", "bar"}'`


## Additional context
[https://www.postgresql.org/docs/current/arrays.html](https://www.postgresql.org/docs/current/arrays.html)
