### PR TITLE
Fix malformed array literal cause by Contains & ContainedBy functions

### DIFF
--- a/filterbuilder.go
+++ b/filterbuilder.go
@@ -152,12 +152,26 @@ func (f *FilterBuilder) In(column string, values []string) *FilterBuilder {
 }
 
 func (f *FilterBuilder) Contains(column string, value []string) *FilterBuilder {
-	f.params[column] = "cs." + strings.Join(value, ",")
+	newValue := []string{}
+	for _, v := range value {
+		newValue = append(newValue, fmt.Sprintf("%#v", v))
+	}
+
+	valueString := fmt.Sprintf("{%s}", strings.Join(newValue, ","))
+	
+	f.params[column] = "cs." + valueString
 	return f
 }
 
 func (f *FilterBuilder) ContainedBy(column string, value []string) *FilterBuilder {
-	f.params[column] = "cd." + strings.Join(value, ",")
+	newValue := []string{}
+	for _, v := range value {
+		newValue = append(newValue, fmt.Sprintf("%#v", v))
+	}
+
+	valueString := fmt.Sprintf("{%s}", strings.Join(newValue, ","))
+	
+	f.params[column] = "cd." + valueString
 	return f
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Correctly formatting the array used by the Contains & ContainedBy functions


Bug fix, feature, docs update, ...
Arrays in Postgres use this string format `{10000, 10000, 10000, 10000}` or `{"meeting", "lunch"}`

## What is the current behavior?
value `[]string{"foo", "bar"}` turns into `foo bar`

Please link any relevant issues here.
https://github.com/supabase-community/postgrest-go/pull/43

## What is the new behavior?
Will turn values `[]string{"foo", "bar"} into '{"foo", "bar"}`


## Additional context
https://www.postgresql.org/docs/current/arrays.html
