### PR TITLE
Added ctx arguments to execute

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -2,6 +2,7 @@ package postgrest
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,14 +26,14 @@ type ExecuteError struct {
 	Message string `json:"message"`
 }
 
-func executeHelper(client *Client, method string, body []byte, urlFragments []string, headers map[string]string, params map[string]string) ([]byte, countType, error) {
+func executeHelper(ctx context.Context, client *Client, method string, body []byte, urlFragments []string, headers map[string]string, params map[string]string) ([]byte, countType, error) {
 	if client.ClientError != nil {
 		return nil, 0, client.ClientError
 	}
 
 	readerBody := bytes.NewBuffer(body)
 	baseUrl := path.Join(append([]string{client.Transport.baseURL.Path}, urlFragments...)...)
-	req, err := http.NewRequest(method, baseUrl, readerBody)
+	req, err := http.NewRequestWithContext(ctx, method, baseUrl, readerBody)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error creating request: %s", err.Error())
 	}
@@ -86,17 +87,17 @@ func executeHelper(client *Client, method string, body []byte, urlFragments []st
 	return respBody, count, nil
 }
 
-func executeString(client *Client, method string, body []byte, urlFragments []string, headers map[string]string, params map[string]string) (string, countType, error) {
-	resp, count, err := executeHelper(client, method, body, urlFragments, headers, params)
+func executeString(ctx context.Context, client *Client, method string, body []byte, urlFragments []string, headers map[string]string, params map[string]string) (string, countType, error) {
+	resp, count, err := executeHelper(ctx, client, method, body, urlFragments, headers, params)
 	return string(resp), count, err
 }
 
-func execute(client *Client, method string, body []byte, urlFragments []string, headers map[string]string, params map[string]string) ([]byte, countType, error) {
-	return executeHelper(client, method, body, urlFragments, headers, params)
+func execute(ctx context.Context, client *Client, method string, body []byte, urlFragments []string, headers map[string]string, params map[string]string) ([]byte, countType, error) {
+	return executeHelper(ctx, client, method, body, urlFragments, headers, params)
 }
 
-func executeTo(client *Client, method string, body []byte, to interface{}, urlFragments []string, headers map[string]string, params map[string]string) (countType, error) {
-	resp, count, err := executeHelper(client, method, body, urlFragments, headers, params)
+func executeTo(ctx context.Context, client *Client, method string, body []byte, to interface{}, urlFragments []string, headers map[string]string, params map[string]string) (countType, error) {
+	resp, count, err := executeHelper(ctx, client, method, body, urlFragments, headers, params)
 
 	if err != nil {
 		return count, err

--- a/filterbuilder.go
+++ b/filterbuilder.go
@@ -25,8 +25,8 @@ func (f *FilterBuilder) ExecuteString() (string, int64, error) {
 	return executeString(context.Background(), f.client, f.method, f.body, []string{f.tableName}, f.headers, f.params)
 }
 
-// Execute runs the PostgREST query with the given context, returning the
-// result as a byte slice.
+// ExecuteStringWithContext runs the PostgREST query, returning the result as
+// a JSON string.
 func (f *FilterBuilder) ExecuteStringWithContext(ctx context.Context) (string, int64, error) {
 	return executeString(ctx, f.client, f.method, f.body, []string{f.tableName}, f.headers, f.params)
 }
@@ -36,8 +36,8 @@ func (f *FilterBuilder) Execute() ([]byte, int64, error) {
 	return execute(context.Background(), f.client, f.method, f.body, []string{f.tableName}, f.headers, f.params)
 }
 
-// Execute runs the PostgREST query with the given context, returning the
-// result as a byte slice.
+// ExecuteWithContext runs the PostgREST query with the given context,
+// returning the result as a byte slice.
 func (f *FilterBuilder) ExecuteWithContext(ctx context.Context) ([]byte, int64, error) {
 	return execute(ctx, f.client, f.method, f.body, []string{f.tableName}, f.headers, f.params)
 }
@@ -49,9 +49,9 @@ func (f *FilterBuilder) ExecuteTo(to interface{}) (countType, error) {
 	return executeTo(context.Background(), f.client, f.method, f.body, to, []string{f.tableName}, f.headers, f.params)
 }
 
-// ExecuteTo runs the PostgREST query with the given context, encoding the
-// result to the supplied interface. Note that the argument for the to
-// parameter should always be a reference to a slice.
+// ExecuteToWithContext runs the PostgREST query with the given context,
+// encoding the result to the supplied interface. Note that the argument for
+// the to parameter should always be a reference to a slice.
 func (f *FilterBuilder) ExecuteToWithContext(ctx context.Context, to interface{}) (countType, error) {
 	return executeTo(ctx, f.client, f.method, f.body, to, []string{f.tableName}, f.headers, f.params)
 }

--- a/filterbuilder.go
+++ b/filterbuilder.go
@@ -1,6 +1,7 @@
 package postgrest
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -21,19 +22,38 @@ type FilterBuilder struct {
 // ExecuteString runs the PostgREST query, returning the result as a JSON
 // string.
 func (f *FilterBuilder) ExecuteString() (string, int64, error) {
-	return executeString(f.client, f.method, f.body, []string{f.tableName}, f.headers, f.params)
+	return executeString(context.Background(), f.client, f.method, f.body, []string{f.tableName}, f.headers, f.params)
+}
+
+// Execute runs the PostgREST query with the given context, returning the
+// result as a byte slice.
+func (f *FilterBuilder) ExecuteStringWithContext(ctx context.Context) (string, int64, error) {
+	return executeString(ctx, f.client, f.method, f.body, []string{f.tableName}, f.headers, f.params)
 }
 
 // Execute runs the PostgREST query, returning the result as a byte slice.
 func (f *FilterBuilder) Execute() ([]byte, int64, error) {
-	return execute(f.client, f.method, f.body, []string{f.tableName}, f.headers, f.params)
+	return execute(context.Background(), f.client, f.method, f.body, []string{f.tableName}, f.headers, f.params)
+}
+
+// Execute runs the PostgREST query with the given context, returning the
+// result as a byte slice.
+func (f *FilterBuilder) ExecuteWithContext(ctx context.Context) ([]byte, int64, error) {
+	return execute(ctx, f.client, f.method, f.body, []string{f.tableName}, f.headers, f.params)
 }
 
 // ExecuteTo runs the PostgREST query, encoding the result to the supplied
 // interface. Note that the argument for the to parameter should always be a
 // reference to a slice.
 func (f *FilterBuilder) ExecuteTo(to interface{}) (countType, error) {
-	return executeTo(f.client, f.method, f.body, to, []string{f.tableName}, f.headers, f.params)
+	return executeTo(context.Background(), f.client, f.method, f.body, to, []string{f.tableName}, f.headers, f.params)
+}
+
+// ExecuteTo runs the PostgREST query with the given context, encoding the
+// result to the supplied interface. Note that the argument for the to
+// parameter should always be a reference to a slice.
+func (f *FilterBuilder) ExecuteToWithContext(ctx context.Context, to interface{}) (countType, error) {
+	return executeTo(ctx, f.client, f.method, f.body, to, []string{f.tableName}, f.headers, f.params)
 }
 
 var filterOperators = []string{"eq", "neq", "gt", "gte", "lt", "lte", "like", "ilike", "is", "in", "cs", "cd", "sl", "sr", "nxl", "nxr", "adj", "ov", "fts", "plfts", "phfts", "wfts"}
@@ -158,7 +178,7 @@ func (f *FilterBuilder) Contains(column string, value []string) *FilterBuilder {
 	}
 
 	valueString := fmt.Sprintf("{%s}", strings.Join(newValue, ","))
-	
+
 	f.params[column] = "cs." + valueString
 	return f
 }
@@ -170,7 +190,7 @@ func (f *FilterBuilder) ContainedBy(column string, value []string) *FilterBuilde
 	}
 
 	valueString := fmt.Sprintf("{%s}", strings.Join(newValue, ","))
-	
+
 	f.params[column] = "cd." + valueString
 	return f
 }

--- a/querybuilder.go
+++ b/querybuilder.go
@@ -23,8 +23,8 @@ func (q *QueryBuilder) ExecuteString() (string, int64, error) {
 	return executeString(context.Background(), q.client, q.method, q.body, []string{q.tableName}, q.headers, q.params)
 }
 
-// Execute runs the PostgREST query with the given context, returning the
-// result as a byte slice.
+// ExecuteStringWithContext runs the PostgREST query, returning the result as
+// a JSON string.
 func (q *QueryBuilder) ExecuteStringWithContext(ctx context.Context) (string, int64, error) {
 	return executeString(ctx, q.client, q.method, q.body, []string{q.tableName}, q.headers, q.params)
 }
@@ -34,8 +34,8 @@ func (q *QueryBuilder) Execute() ([]byte, int64, error) {
 	return execute(context.Background(), q.client, q.method, q.body, []string{q.tableName}, q.headers, q.params)
 }
 
-// Execute runs the PostgREST query with the given context, returning the
-// result as a byte slice.
+// ExecuteWithContext runs the PostgREST query with the given context,
+// returning the result as a byte slice.
 func (q *QueryBuilder) ExecuteWithContext(ctx context.Context) ([]byte, int64, error) {
 	return execute(ctx, q.client, q.method, q.body, []string{q.tableName}, q.headers, q.params)
 }
@@ -47,9 +47,9 @@ func (q *QueryBuilder) ExecuteTo(to interface{}) (int64, error) {
 	return executeTo(context.Background(), q.client, q.method, q.body, to, []string{q.tableName}, q.headers, q.params)
 }
 
-// ExecuteTo runs the PostgREST query with the given context, encoding the
-// result to the supplied interface. Note that the argument for the to
-// parameter should always be a reference to a slice.
+// ExecuteToWithContext runs the PostgREST query with the given context,
+// encoding the result to the supplied interface. Note that the argument for
+// the to parameter should always be a reference to a slice.
 func (q *QueryBuilder) ExecuteToWithContext(ctx context.Context, to interface{}) (int64, error) {
 	return executeTo(ctx, q.client, q.method, q.body, to, []string{q.tableName}, q.headers, q.params)
 }

--- a/querybuilder.go
+++ b/querybuilder.go
@@ -1,6 +1,7 @@
 package postgrest
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -16,22 +17,41 @@ type QueryBuilder struct {
 	params    map[string]string
 }
 
-// ExecuteString runs the Postgrest query, returning the result as a JSON
+// ExecuteString runs the PostgREST query, returning the result as a JSON
 // string.
 func (q *QueryBuilder) ExecuteString() (string, int64, error) {
-	return executeString(q.client, q.method, q.body, []string{q.tableName}, q.headers, q.params)
+	return executeString(context.Background(), q.client, q.method, q.body, []string{q.tableName}, q.headers, q.params)
+}
+
+// Execute runs the PostgREST query with the given context, returning the
+// result as a byte slice.
+func (q *QueryBuilder) ExecuteStringWithContext(ctx context.Context) (string, int64, error) {
+	return executeString(ctx, q.client, q.method, q.body, []string{q.tableName}, q.headers, q.params)
 }
 
 // Execute runs the Postgrest query, returning the result as a byte slice.
 func (q *QueryBuilder) Execute() ([]byte, int64, error) {
-	return execute(q.client, q.method, q.body, []string{q.tableName}, q.headers, q.params)
+	return execute(context.Background(), q.client, q.method, q.body, []string{q.tableName}, q.headers, q.params)
 }
 
-// ExecuteTo runs the Postgrest query, encoding the result to the supplied
+// Execute runs the PostgREST query with the given context, returning the
+// result as a byte slice.
+func (q *QueryBuilder) ExecuteWithContext(ctx context.Context) ([]byte, int64, error) {
+	return execute(ctx, q.client, q.method, q.body, []string{q.tableName}, q.headers, q.params)
+}
+
+// ExecuteTo runs the PostgREST query, encoding the result to the supplied
 // interface. Note that the argument for the to parameter should always be a
 // reference to a slice.
 func (q *QueryBuilder) ExecuteTo(to interface{}) (int64, error) {
-	return executeTo(q.client, q.method, q.body, to, []string{q.tableName}, q.headers, q.params)
+	return executeTo(context.Background(), q.client, q.method, q.body, to, []string{q.tableName}, q.headers, q.params)
+}
+
+// ExecuteTo runs the PostgREST query with the given context, encoding the
+// result to the supplied interface. Note that the argument for the to
+// parameter should always be a reference to a slice.
+func (q *QueryBuilder) ExecuteToWithContext(ctx context.Context, to interface{}) (int64, error) {
+	return executeTo(ctx, q.client, q.method, q.body, to, []string{q.tableName}, q.headers, q.params)
 }
 
 // Select performs vertical filtering.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added `context.Context` argument to each variant of the `Execute()` function, enabling users to pass context-based cancelation to the functions. 

## What is the current behavior?

There is no way to set deadlines/timeouts for operations to the DB. 

## What is the new behavior?

We allow the user to pass in a `ctx` to new variants of the `Execute()` function that are passed in to `http.NewRequestWithContext()` rather than the plain `http.NewRequest`, which defaults to `context.Background()`, which has no timeout.

## Additional context

More info: https://go.dev/doc/database/cancel-operations
